### PR TITLE
Fix  TrueIfAny result

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -138,9 +138,13 @@ done: // break out of inner switch
 	// Based on the results of the child rules, determine the result of the parent rule
 	switch r.EvalOptions.TrueIfAny {
 	case true:
-		// If any of the child rules passed AND the parent's expression passed, the rule passes
-		if u.ExpressionPass && passCount > 0 {
-			u.Pass = true
+		if u.ExpressionPass {
+			// If none of the child rules passed AND the parent's expression passed, the rule
+			// shouldn't pass
+			hasChildren := len(r.Rules) > 0
+			if hasChildren && passCount == 0 {
+				u.Pass = false
+			}
 		}
 	case false:
 		// If one or more of child rules failed, we will fail also, regardless of the parent rule's result


### PR DESCRIPTION
## Overview

[Original Code](https://github.com/ezachrisen/indigo/blob/master/engine.go#L140) 

```go
// Based on the results of the child rules, determine the result of the parent rule
1. switch r.EvalOptions.TrueIfAny {
2. case true:
3.   // If any of the child rules passed AND the parent's expression passed, the rule passes
4.   if u.ExpressionPass && passCount > 0 {
5. 	  u.Pass = true
6.   }
```

Since that the `u.Pass` receives the value of the `u.ExpressionPass`, [line 85](https://github.com/ezachrisen/indigo/blob/master/engine.go#L85). The actual value for a giving rule with multiples childs will only depend of the expression itself.

For example, let's assume the following hierarchy:

```
Expression result

root_rule           True
    rule_l1             True
        rule_l1-1           True
        rule_l1-2           True
    rule_l2             False
```

If the expression for the `root_rule` is `true` (line 85) then,  even if the line `5` execute, the response is still the same (`true`).

However, if we assume that the `root_rule` is `true` and none of its children is `true`:

```
Expression result

root_rule           True
    rule_l1             False
        rule_l1-1           True
        rule_l1-2           False
    rule_l2             False
```

The line `5` won't be executed. Thus, the `result.Pass == true`.

Therefore, it'll depend only of the `root_rule` itself.

## Expected behavior?

If the expected behavior is:
- The rule will be `true` *if, and only if*,  the expression evaluates to `true` **AND**
  - if there's no children/rules
  - **OR**, there's children, but at least one of them is `true` ([line 229](https://github.com/ezachrisen/indigo/blob/master/engine.go#L229))

## Conclusion

Therefore, this PR solves this scenario where none of the child rules passed.