### PR TITLE
feat: ability to keep failed rules, if their own expression is true

### DIFF
--- a/cel/example_test.go
+++ b/cel/example_test.go
@@ -847,7 +847,7 @@ func Example_protoConstructionConditional() {
 	// 0
 }
 
-// Example_alarms illustrates using the DiscardFail option to only return
+// Example_alarms illustrates using the FailAction option to only return
 // true rules from evaluation
 func Example_alarms() {
 
@@ -866,7 +866,7 @@ func Example_alarms() {
 
 	// Setting this option so we only get back
 	// rules that evaluate to 'true'
-	rule.EvalOptions.DiscardFail = true
+	rule.EvalOptions.FailAction = indigo.DiscardFailures
 
 	rule.Rules["cpu_alarm"] = &indigo.Rule{
 		ID:     "cpu_alarm",
@@ -912,7 +912,7 @@ func Example_alarms() {
 	// Unordered output: cpu_alarm
 }
 
-// Example_alarms illustrates using the DiscardFail option to only return
+// Example_alarms illustrates using the FailAction option to only return
 // true rules from evaluation with a multi-level hierarchy
 func Example_alarmsTwoLevel() {
 
@@ -932,7 +932,7 @@ func Example_alarmsTwoLevel() {
 
 	// Setting this option so we only get back
 	// rules that evaluate to 'true'
-	rule.EvalOptions.DiscardFail = true
+	rule.EvalOptions.FailAction = indigo.DiscardFailures
 
 	rule.Rules["cpu_alarm"] = &indigo.Rule{
 		ID:     "cpu_alarm",
@@ -950,8 +950,8 @@ func Example_alarmsTwoLevel() {
 		ID:    "memory_alarm",
 		Rules: map[string]*indigo.Rule{},
 		EvalOptions: indigo.EvalOptions{
-			DiscardFail: false,
-			TrueIfAny:   true,
+			FailAction: indigo.KeepFailures,
+			TrueIfAny:  true,
 		},
 	}
 

--- a/results.go
+++ b/results.go
@@ -98,7 +98,7 @@ func (u *Result) resultsToRows(n int) []table.Row {
 		trueFalse(fmt.Sprintf("%t", u.EvalOptions.StopFirstPositiveChild)),
 		trueFalse(fmt.Sprintf("%t", u.EvalOptions.StopFirstNegativeChild)),
 		trueFalse(fmt.Sprintf("%t", u.EvalOptions.DiscardPass)),
-		trueFalse(fmt.Sprintf("%t", u.EvalOptions.DiscardFail)),
+		trueFalse(fmt.Sprintf("%d", u.EvalOptions.FailAction)),
 	}
 
 	rows = append(rows, row)


### PR DESCRIPTION
added the ability to keep the results of failed rules, if their expression is true via the new DiscardOnlyIfExpressionFailed option