### PR TITLE
Mutation and Rule Evaluation Counts

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -70,12 +70,14 @@ func (e *DefaultEngine) Eval(ctx context.Context, r *Rule,
 	if err != nil {
 		return nil, fmt.Errorf("rule %s: %w", r.ID, err)
 	}
+
 	u := &Result{
-		Rule:           r,
-		ExpressionPass: true, // default boolean result
-		Value:          val,
-		Diagnostics:    diagnostics,
-		EvalOptions:    o,
+		Rule:            r,
+		ExpressionPass:  true, // default boolean result
+		Value:           val,
+		Diagnostics:     diagnostics,
+		EvalOptions:     o,
+		EvaluationCount: 1,
 	}
 
 	// If the evaluation returned a boolean, set the Result's value,
@@ -99,7 +101,8 @@ func (e *DefaultEngine) Eval(ctx context.Context, r *Rule,
 		return nil, err
 	}
 	u.Results = eu.results
-	u.RulesEvaluated = eu.evaluated
+	u.RulesEvaluated = append(u.RulesEvaluated, eu.evaluated...)
+	u.EvaluationCount = u.EvaluationCount + eu.evaluatedCount
 
 	// Based on the results of the child rules, determine the result of the parent rule
 	switch r.EvalOptions.TrueIfAny {
@@ -185,6 +188,7 @@ func (e *DefaultEngine) evalChildren(ctx context.Context, rules []*Rule, d map[s
 			r.evaluated = append(r.evaluated, res.evaluated...)
 			r.failCount = r.failCount + res.failCount
 			r.passCount = r.passCount + res.passCount
+			r.evaluatedCount = r.evaluatedCount + res.evaluatedCount
 			maps.Copy(r.results, res.results)
 		case err := <-errCh:
 			// A worker encountered an error - stop processing and return it
@@ -198,10 +202,11 @@ func (e *DefaultEngine) evalChildren(ctx context.Context, rules []*Rule, d map[s
 
 // evalResult is a convenience type to let us pass multiple values on a channel
 type evalResult struct {
-	passCount int
-	failCount int
-	results   map[string]*Result
-	evaluated []*Rule
+	passCount      int
+	failCount      int
+	results        map[string]*Result
+	evaluated      []*Rule
+	evaluatedCount int
 }
 
 // makeChunks divides a range [start, len) into batches of the specified size.
@@ -381,6 +386,7 @@ func (e *DefaultEngine) evalRuleSlice(ctx context.Context, rules []*Rule, d map[
 			if err != nil {
 				return r, err
 			}
+			r.evaluatedCount = r.evaluatedCount + result.EvaluationCount
 
 			// If the child rule failed, either due to its own expression evaluation
 			// or its children, we have encountered a failure, and we'll count it

--- a/engine_test.go
+++ b/engine_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -89,7 +91,6 @@ func TestTrueIfAnyBehavior(t *testing.T) {
 func TestEvaluationTraversalDefault(t *testing.T) {
 	e := indigo.NewEngine(newMockEvaluator())
 	r := makeRule()
-
 	expectedResults := map[string]bool{
 		"rule1": true,
 		"D":     true,
@@ -117,6 +118,9 @@ func TestEvaluationTraversalDefault(t *testing.T) {
 	result, err := e.Eval(context.Background(), r, map[string]any{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if g, w := result.EvaluationCount, len(expectedResults); w != g {
+		t.Errorf("wanted %d, got %d", w, g)
 	}
 	//	fmt.Println(m.rulesTested)
 	//	fmt.Println(result)
@@ -208,6 +212,9 @@ func TestEvaluationTraversalAlphaSort(t *testing.T) {
 	if !reflect.DeepEqual(expectedOrder, flattenResultsEvaluated(result)) {
 		t.Error("not all rules were evaluated")
 	}
+	if g, w := result.EvaluationCount, len(expectedResults); w != g {
+		t.Errorf("wanted %d, got %d", w, g)
+	}
 }
 
 // Test that the engine checks for nil data and rule
@@ -271,8 +278,9 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		prep func(*indigo.Rule)     // a function called to prep the rule before compilation and evaluation
-		want func() map[string]bool // a function returning an edited copy of w after options are applied
+		prep          func(*indigo.Rule)     // a function called to prep the rule before compilation and evaluation
+		want          func() map[string]bool // a function returning an edited copy of w after options are applied
+		wantEvalCount int                    // the number of rules that should have been evaluated
 	}{
 		"Default Options": {
 			prep: func(r *indigo.Rule) {
@@ -280,6 +288,7 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 			want: func() map[string]bool {
 				return copyMap(w)
 			},
+			wantEvalCount: len(w),
 		},
 
 		"StopIfParentNegative": {
@@ -289,6 +298,7 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 			want: func() map[string]bool {
 				return deleteKeys(copyMap(w), "b1", "b2", "b3", "b4", "b4-1", "b4-2")
 			},
+			wantEvalCount: 10,
 		},
 		"DiscardPass": {
 			prep: func(r *indigo.Rule) {
@@ -297,6 +307,7 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 			want: func() map[string]bool {
 				return deleteKeys(copyMap(w), "b4-1")
 			},
+			wantEvalCount: len(w),
 		},
 		"DiscardFailures": {
 			prep: func(r *indigo.Rule) {
@@ -305,6 +316,7 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 			want: func() map[string]bool {
 				return deleteKeys(copyMap(w), "b2", "b4", "b4-1", "b4-2") // b4-1 is elim. because b4 is
 			},
+			wantEvalCount: len(w),
 		},
 		"DiscardPass & DiscardFailures": {
 			prep: func(r *indigo.Rule) {
@@ -314,6 +326,7 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 			want: func() map[string]bool {
 				return deleteKeys(copyMap(w), "b1", "b2", "b3", "b4", "b4-1", "b4-2")
 			},
+			wantEvalCount: len(w),
 		},
 		"DiscardPass & DiscardFailures on Root": {
 			prep: func(r *indigo.Rule) {
@@ -323,8 +336,9 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 			want: func() map[string]bool {
 				return map[string]bool{"rule1": true}
 			},
+			wantEvalCount: len(w),
 		},
-		"StopFirstPositiveChildX": {
+		"StopFirstPositiveChild": {
 			prep: func(r *indigo.Rule) {
 				r.Rules["B"].EvalOptions.StopFirstPositiveChild = true
 				r.Rules["B"].EvalOptions.SortFunc = indigo.SortRulesAlpha
@@ -332,6 +346,7 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 			want: func() map[string]bool {
 				return deleteKeys(copyMap(w), "b2", "b3", "b4", "b4-1", "b4-2")
 			},
+			wantEvalCount: 11,
 		},
 		"StopFirstNegativeChild": {
 			prep: func(r *indigo.Rule) {
@@ -341,6 +356,7 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 			want: func() map[string]bool {
 				return deleteKeys(copyMap(w), "b3", "b4", "b4-1", "b4-2")
 			},
+			wantEvalCount: 12,
 		},
 		"StopFirstNegativeChild & StopFirstPositiveChild": {
 			prep: func(r *indigo.Rule) {
@@ -351,6 +367,7 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 			want: func() map[string]bool {
 				return deleteKeys(copyMap(w), "b2", "b3", "b4", "b4-1", "b4-2")
 			},
+			wantEvalCount: 11,
 		},
 		"Multiple Options": {
 			prep: func(r *indigo.Rule) {
@@ -361,6 +378,7 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 			want: func() map[string]bool {
 				return deleteKeys(copyMap(w), "b1", "b3", "b4-1", "e1", "e2", "e3")
 			},
+			wantEvalCount: 13,
 		},
 		"Delete Rule": {
 			prep: func(r *indigo.Rule) {
@@ -369,6 +387,7 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 			want: func() map[string]bool {
 				return deleteKeys(copyMap(w), "b1")
 			},
+			wantEvalCount: len(w) - 1,
 		},
 		"Add Rule": {
 			prep: func(r *indigo.Rule) {
@@ -383,6 +402,7 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 				w["x"] = true
 				return w
 			},
+			wantEvalCount: len(w) + 1,
 		},
 		"Update Rule": { // TODO and forget to compile; stale program?
 			prep: func(r *indigo.Rule) {
@@ -393,15 +413,15 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 				w["b4"] = true
 				return w
 			},
+			wantEvalCount: len(w),
 		},
 	}
 
 	for k, c := range cases {
-		c := c
 		t.Run(k, func(t *testing.T) {
 			r := makeRule()
 			c.prep(r)
-			err := e.Compile(r)
+			err := e.Compile(r, indigo.CollectDiagnostics(true))
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -410,13 +430,35 @@ func TestEvalOptionsExpressionPassFail(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			//			fmt.Println("got: ", flattenResultsExprResult(u))
-			err = match(flattenResultsExprResult(u), c.want())
+			f := flattenResultsExprResult(u)
+			err = match(f, c.want())
 			if err != nil {
 				t.Errorf("%v", err)
 			}
+
+			if g, w := u.EvaluationCount, c.wantEvalCount; w != g {
+				t.Logf("\n%s\n", r)
+				t.Logf("Result count: %d\n", len(f))
+				for _, id := range slices.Sorted(maps.Keys(f)) {
+					t.Logf("%s\n", id)
+				}
+				t.Logf("\n")
+				ev := ruleIDsEvaluated(u)
+				t.Logf("Evaluated:(doesn't count root) %d (%s)", len(ev), strings.Join(ev, ","))
+				t.Errorf("wanted %d, got %d", w, g)
+			}
 		})
 	}
+}
+
+func ruleIDsEvaluated(u *indigo.Result) (ids []string) {
+	for _, uu := range u.RulesEvaluated {
+		ids = append(ids, uu.ID)
+	}
+	for _, c := range u.Results {
+		ids = append(ids, ruleIDsEvaluated(c)...)
+	}
+	return
 }
 
 // Test the pass/fail of the rule  evaluation with various combinations

--- a/results.go
+++ b/results.go
@@ -50,6 +50,9 @@ type Result struct {
 	// If we're discarding failed/passed rules, they will not be in the results,
 	// and will not show up in diagnostics, but they will be in this list.
 	RulesEvaluated []*Rule
+
+	// Count of the number of rules whose expression was evaluated
+	EvaluationCount int
 }
 
 // Unshard reorganizes the results into the "original" structure of the rule

--- a/shard_test.go
+++ b/shard_test.go
@@ -351,7 +351,7 @@ root
 		// Based on the sharding specification, it shold be placed into "woodlawnForeign"
 		woodlawnForeignJustOK := indigo.NewRule("woodlawnForeignJustOK", `school =="woodlawn" && class == 2026 && gpa > 2.0 && gpa < 3.7 && nationality != "US"`)
 
-		err = v.Mutate(indigo.Add(woodlawnForeignJustOK, "root")) // <-- we can just add it to the root and let sharding place it
+		stats, err := v.Mutate(indigo.Add(woodlawnForeignJustOK, "root")) // <-- we can just add it to the root and let sharding place it
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -379,6 +379,7 @@ root
 
 		debugLogf(t, "After adding new rule, ensuring it ends up in the right shard:\n%s\n", gotTree)
 		assertEqual(wantTree, gotTree, t)
+		checkStats(1, 0, 0, 0, 0, stats, t)
 	})
 }
 
@@ -444,7 +445,7 @@ root
 	assertEqual(wantBefore, beforeTree, t)
 
 	// Delete centralAtRisk from the central shard
-	err = v.Mutate(indigo.Delete("centralAtRisk"))
+	stats, err := v.Mutate(indigo.Delete("centralAtRisk"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -465,9 +466,10 @@ root
     └── woodlawnHonors
 	`
 	assertEqual(wantAfter, afterTree, t)
+	checkStats(0, 0, 0, 1, 0, stats, t)
 
 	// Delete entire central shard
-	err = v.Mutate(indigo.Delete("central"))
+	stats, err = v.Mutate(indigo.Delete("central"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -486,6 +488,7 @@ root
     └── woodlawnHonors
 	`
 	assertEqual(wantAfterDeleteShard, afterDeleteShard, t)
+	checkStats(0, 0, 0, 1, 0, stats, t)
 }
 
 // TestVaultUpdate tests the Vault Update mutation with sharded rules
@@ -551,7 +554,7 @@ root
 	honorsChild := indigo.NewRule("centralHonorsChild", `gpa > 3.9`)
 	updatedHonors.Add(honorsChild)
 
-	err = v.Mutate(indigo.Update(updatedHonors))
+	stats, err := v.Mutate(indigo.Update(updatedHonors))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -573,11 +576,12 @@ root
     └── woodlawnHonors
 	`
 	assertEqual(wantAfter, afterTree, t)
+	checkStats(0, 0, 1, 0, 0, stats, t)
 
 	// Update eastHonors to modify its expression
 	updatedEastExpr := `school =="east" && class == 2026 && gpa > 3.5`
 	updatedEastHonors := indigo.NewRule("eastHonors", updatedEastExpr)
-	err = v.Mutate(indigo.Update(updatedEastHonors))
+	stats, err = v.Mutate(indigo.Update(updatedEastHonors))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -600,6 +604,7 @@ root
     └── woodlawnHonors
 	`
 	assertEqual(wantAfterUpdateEast, afterUpdateEastTree, t)
+	checkStats(0, 0, 1, 0, 0, stats, t)
 
 	// Verify the expression was actually updated
 	updatedRule, _ := v.ImmutableRule().FindRule("eastHonors")
@@ -660,7 +665,7 @@ root
 	// The Update operation should automatically move it to the woodlawn shard
 	updatedExpr := `school =="woodlawn" && class == 2026 && gpa < 2.5`
 	updatedRule := indigo.NewRule("centralAtRisk", updatedExpr)
-	err = v.Mutate(indigo.Update(updatedRule))
+	stats, err := v.Mutate(indigo.Update(updatedRule))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -679,6 +684,7 @@ root
     └── woodlawnHonors
 	`
 	assertEqual(wantAfterUpdate, afterUpdateTree, t)
+	checkStats(0, 0, 1, 0, 1, stats, t)
 
 	// Verify the expression was updated
 	updatedRuleInVault, _ := v.ImmutableRule().FindRule("centralAtRisk")
@@ -761,7 +767,7 @@ root
 
 	// Add a generic rule to default shard (no specific school), then move it to central
 	genericRule := indigo.NewRule("genericRule", `class == 2027`)
-	err = v.Mutate(indigo.Add(genericRule, "default"))
+	stats, err := v.Mutate(indigo.Add(genericRule, "default"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -783,24 +789,29 @@ root
     └── woodlawnHonors
 	`
 	assertEqual(wantAfterAdd, afterAddTree, t)
+	checkStats(1, 0, 0, 0, 0, stats, t)
 
-	// Move genericRule to central (note: since it doesn't match central shard criteria,
-	// it will stay in central because that's where we explicitly requested it to go)
-	err = v.Mutate(indigo.Move("genericRule", "central"))
+	// Try to move genericRule to central (note: since it doesn't match central shard criteria,
+	// it will stay in default)
+	stats, err = v.Mutate(indigo.Move("genericRule", "central"))
 	if err == nil {
 		t.Fatalf("expected error that moving a rule to a shard is not allowed")
 	}
+	checkStats(0, 0, 0, 0, 0, stats, t)
+	debugLogf(t, "After attempting to move bingo:\n%s\n\n", v.ImmutableRule().Tree())
 
 	// Let's add a rule to a non-shard rule, then move it to another non-shard rule
-	err = v.Mutate(indigo.Add(indigo.NewRule("bingo", ""), "woodlawnHonors"))
+	stats, err = v.Mutate(indigo.Add(indigo.NewRule("bingo", ""), "woodlawnHonors"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	checkStats(1, 0, 0, 0, 0, stats, t)
 
-	err = v.Mutate(indigo.Move("bingo", "genericRule"))
+	stats, err = v.Mutate(indigo.Move("bingo", "genericRule"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	checkStats(0, 1, 0, 0, 0, stats, t)
 
 	afterMoveTree := v.ImmutableRule().Tree()
 	debugLogf(t, "After moving bingo:\n%s\n\n", afterMoveTree)
@@ -905,7 +916,7 @@ root
 	// The Update operation should automatically move it to the woodlawn shard
 	updatedExpr := `school =="woodlawn" && class == 2026 && gpa < 2.5`
 	updatedRule := indigo.NewRule("centralAtRisk", updatedExpr) // <--- this is an existing rule ID
-	err = v.Mutate(indigo.Upsert(updatedRule))
+	stats, err := v.Mutate(indigo.Upsert(updatedRule))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -924,6 +935,7 @@ root
     └── woodlawnHonors
 	`
 	assertEqual(wantAfterUpdate, afterUpdateTree, t)
+	checkStats(0, 0, 1, 0, 1, stats, t)
 
 	// Verify the expression was updated
 	updatedRuleInVault, _ := v.ImmutableRule().FindRule("centralAtRisk")
@@ -948,7 +960,7 @@ root
 	// Now let's add a new rule using the upsert mutation
 	newExpr := `school =="Central" && class == 2026`
 	newRule := indigo.NewRule("myNewRule", newExpr) // <--- this is an new rule ID
-	err = v.Mutate(indigo.Upsert(newRule))
+	stats, err = v.Mutate(indigo.Upsert(newRule))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -964,6 +976,7 @@ root
 	afterUpsertNewTree := v.ImmutableRule().Tree()
 	debugLogf(t, "After adding newRule (should be in central shard):\n%s\n", afterUpdateTree)
 	assertEqual(wantAfterUpsertNew, afterUpsertNewTree, t)
+	checkStats(1, 0, 0, 0, 0, stats, t)
 }
 
 // Helper function to compare rule trees from the rule.Tree() method
@@ -974,5 +987,24 @@ func assertEqual(want, got string, t *testing.T) {
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 		t.Errorf("Wanted\n%s\n\nGot\n%s\n", want, got)
+	}
+}
+
+func checkStats(add, move, update, delete, changedShards int, s indigo.MutationStats, t *testing.T) {
+	t.Helper()
+	if add != s.Added {
+		t.Errorf("wanted %d adds, got %d", add, s.Added)
+	}
+	if move != s.Moved {
+		t.Errorf("wanted %d moves, got %d", move, s.Moved)
+	}
+	if update != s.Updated {
+		t.Errorf("wanted %d updates, got %d", update, s.Updated)
+	}
+	if delete != s.Deleted {
+		t.Errorf("wanted %d deletes, got %d", delete, s.Deleted)
+	}
+	if changedShards != s.ChangedShards {
+		t.Errorf("wanted %d shard changes, got %d", changedShards, s.ChangedShards)
 	}
 }

--- a/vault.go
+++ b/vault.go
@@ -38,7 +38,8 @@ type Vault struct {
 	compileOptions []CompilationOption
 
 	// An optional timestamp maintained by the client to keep track of when the
-	// Vault was last updated. Initialized to time.Time{} on Vault creation.
+	// Vault was last updated. Initialized to time.Time{} on Vault creation to ensure
+	// LastUpdate() never returns nil.
 	lastUpdate atomic.Pointer[time.Time]
 }
 
@@ -103,19 +104,48 @@ type Mutation struct {
 	// we will not try to find the right shard for the rule,
 	// rather it will be placed in the newParent rule
 	doNotShard bool
+
+	// Determines how we're going to count this mutation when we report
+	// at the end of applying mutations. For example, because we process a "move" as
+	// a "delete" from one parent and an "add" to another (replacing the "move"
+	// mutation we were given) we need to be able to control how mutations are
+	// counted as they are applied.
+	countAs mutationOp
+
+	// Indicates that the mutation caused the rule to be moved to a different shard
+	shardChange bool
+}
+
+// MutationStats contains counts of changes made to a [Vault] via [Mutate].
+// The counts reflect the operations performed, not the number of rules affected.
+// For example, a Delete operation that deletes a rule that has 1,000 children will
+// be counted as a single delete.
+//
+// Upserts will be reported as either Added or Updated.
+//
+// Updates that result in moving a rule to a different shard will be counted
+// in the Updated count and the ChangedShards count.
+//
+// Updates to the Vault lastUpdate timestamp are not counted.
+type MutationStats struct {
+	Added         int
+	Moved         int
+	Updated       int
+	Deleted       int
+	ChangedShards int
 }
 
 // mutationOp is an enum for the types of mutations supported by the Vault
 type mutationOp int
 
 const (
-	add mutationOp = iota
+	noOp mutationOp = iota
+	add
 	update
 	upsert
 	deleteOp
 	move
-	timeUpdate
-	noOp // does nothing
+	timeUpdate // updates the vault's last update timestamp
 )
 
 // Add returns a mutation that adds the rule to the parent.
@@ -129,22 +159,38 @@ func Add(r *Rule, parent string) Mutation {
 		return Mutation{op: noOp}
 	}
 	return Mutation{
-		id:     r.ID,
-		rule:   r,
-		parent: parent,
-		op:     add,
+		id:      r.ID,
+		rule:    r,
+		parent:  parent,
+		op:      add,
+		countAs: add,
+	}
+}
+
+func addWOp(r *Rule, parent string, countAs mutationOp, shardChange bool) Mutation {
+	if r == nil {
+		return Mutation{op: noOp}
+	}
+	return Mutation{
+		id:          r.ID,
+		rule:        r,
+		parent:      parent,
+		op:          add,
+		countAs:     countAs,
+		shardChange: shardChange,
 	}
 }
 
 // Add returns a mutation that adds the rule to the parent,
 // bypassing any sharding specifications.
-func addDoNotShard(r *Rule, parent string) Mutation {
+func addDoNotShard(r *Rule, parent string, countAs mutationOp) Mutation {
 	return Mutation{
 		id:         r.ID,
 		rule:       r,
 		parent:     parent,
 		op:         add,
 		doNotShard: true,
+		countAs:    countAs,
 	}
 }
 
@@ -157,9 +203,10 @@ func Update(r *Rule) Mutation {
 		return Mutation{op: noOp}
 	}
 	return Mutation{
-		id:   r.ID,
-		rule: r,
-		op:   update,
+		id:      r.ID,
+		rule:    r,
+		op:      update,
+		countAs: update,
 	}
 }
 
@@ -175,9 +222,10 @@ func Upsert(r *Rule) Mutation {
 		return Mutation{op: noOp}
 	}
 	return Mutation{
-		id:   r.ID,
-		rule: r,
-		op:   upsert,
+		id:      r.ID,
+		rule:    r,
+		op:      upsert,
+		countAs: noOp,
 	}
 }
 
@@ -185,8 +233,19 @@ func Upsert(r *Rule) Mutation {
 // the operation is skipped with no error.
 func Delete(id string) Mutation {
 	return Mutation{
-		id: id,
-		op: deleteOp,
+		id:      id,
+		op:      deleteOp,
+		countAs: deleteOp,
+	}
+}
+
+// Delete deletes the rule with the id. If the rule does not exist,
+// the operation is skipped with no error.
+func deleteWOp(id string, countAs mutationOp) Mutation {
+	return Mutation{
+		id:      id,
+		op:      deleteOp,
+		countAs: countAs,
 	}
 }
 
@@ -197,6 +256,7 @@ func Move(id string, newParent string) Mutation {
 		id:        id,
 		newParent: newParent,
 		op:        move,
+		countAs:   move,
 	}
 }
 
@@ -211,12 +271,11 @@ func LastUpdate(t time.Time) Mutation {
 // Mutate makes the changes to the rule stored in the Vault, applying the
 // mutations in sequence.
 // At the end of all mutations, the resulting root rule becomes the new
-// active rule in the vault, and can be retrieved with the [Rule] function.
+// active rule in the vault, and can be retrieved with the [ImmutableRule] function.
 //
 // Clients do not see the updated rules until all mutations submitted to [Mutate]
-// succeed; if one fails no updates are applied.
-//
-// This ensures that clients see a consistent rule set without partial updates.
+// succeed; if any mutation fails no updates are applied. This ensures that clients
+// see a consistent rule set without partial updates.
 //
 // Mutations incur memory cost equal to the total size of the ancestor rules of
 // the rule being mutated; only children who are affected are copied.
@@ -234,11 +293,14 @@ func LastUpdate(t time.Time) Mutation {
 //
 // Moves incur the cost in both the origin and destination ancestors.
 //
-// To clear a vault, replace the root rule with a new, empty rule.
+// To clear a vault, replace the root rule with a new, empty rule as the first
+// mutation in the mutations variadic, followed by the rules you want in the new root.
 //
 // Vaults support sharding, and will automatically place mutated rules in the correct
 // shard.
-func (v *Vault) Mutate(mutations ...Mutation) error {
+//
+// Returns counts of operations performed on the Vault in the [MutationStats].
+func (v *Vault) Mutate(mutations ...Mutation) (stats MutationStats, err error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
@@ -246,17 +308,17 @@ func (v *Vault) Mutate(mutations ...Mutation) error {
 
 	mut, err := v.preProcessMoves(r, mutations)
 	if err != nil {
-		return fmt.Errorf("preprocessing moves: %w", err)
+		return stats, fmt.Errorf("preprocessing moves: %w", err)
 	}
 
 	mut, err = v.preProcessUpserts(r, mut)
 	if err != nil {
-		return fmt.Errorf("preprocessing upserts: %w", err)
+		return stats, fmt.Errorf("preprocessing upserts: %w", err)
 	}
 
 	mut, err = v.preProcessShardChanges(r, mut)
 	if err != nil {
-		return fmt.Errorf("preprocessing shard changes: %w", err)
+		return stats, fmt.Errorf("preprocessing shard changes: %w", err)
 	}
 	return v.applyMutations(r, mut)
 }
@@ -285,8 +347,8 @@ func (v *Vault) preProcessMoves(root *Rule, mut []Mutation) ([]Mutation, error) 
 		if p.shard {
 			return nil, fmt.Errorf("attempt to place rule in shard %s", p.ID)
 		}
-		mut = append(mut, Delete(m.id))                     // delete from current parent
-		mut = append(mut, addDoNotShard(rule, m.newParent)) // add to new parent
+		mut = append(mut, deleteWOp(m.id, noOp))                  // delete from current parent
+		mut = append(mut, addDoNotShard(rule, m.newParent, move)) // add to new parent, count as a move
 	}
 	return mut, nil
 }
@@ -337,8 +399,8 @@ func (v *Vault) preProcessShardChanges(root *Rule, mut []Mutation) ([]Mutation, 
 
 		switch {
 		case targetParent != nil && currentParent.ID != targetParent.ID:
-			u = append(u, Delete(m.id))                 // delete from current parent
-			u = append(u, Add(m.rule, targetParent.ID)) // add to new parent
+			u = append(u, deleteWOp(m.id, noOp))                       // delete from current parent
+			u = append(u, addWOp(m.rule, targetParent.ID, m.op, true)) // add to new parent
 		default:
 			u = append(u, m)
 		}
@@ -377,18 +439,17 @@ func destinationShard(root, rr *Rule) *Rule {
 }
 
 // applyMutations performs the mutations against the root rule.
-func (v *Vault) applyMutations(root *Rule, mutations []Mutation) error {
+func (v *Vault) applyMutations(root *Rule, mutations []Mutation) (stats MutationStats, err error) {
 	// we keep track of which rules have already been cloned, i.e., made safe
 	// for modifications.
 	// Map is Original Pointer -> New Copy Pointer
 	alreadyCopied := make(map[*Rule]*Rule)
-	var err error
 	for _, m := range mutations {
 		switch m.op {
 		case deleteOp:
 			root, alreadyCopied, err = v.delete(root, alreadyCopied, m.id)
 			if err != nil {
-				return fmt.Errorf("deleting rule %s: %w", m.id, err)
+				return stats, fmt.Errorf("deleting rule %s: %w", m.id, err)
 			}
 
 		case timeUpdate:
@@ -397,24 +458,44 @@ func (v *Vault) applyMutations(root *Rule, mutations []Mutation) error {
 		case add:
 			root, alreadyCopied, err = v.add(root, m.rule, alreadyCopied, m.parent, m.doNotShard)
 			if err != nil {
-				return fmt.Errorf("adding rule %s: %w", m.rule.ID, err)
+				return stats, fmt.Errorf("adding rule %s: %w", m.rule.ID, err)
 			}
 
 		case update:
 			root, alreadyCopied, err = v.update(root, m.rule, alreadyCopied)
 			if err != nil {
-				return fmt.Errorf("updating rule %s: %w", m.rule.ID, err)
+				return stats, fmt.Errorf("updating rule %s: %w", m.rule.ID, err)
 			}
 
 		case move:
-			// we've already handled the move operation in [preprocessMoves]
+			// we've already handled moves in [preprocessMoves]
+			continue
+		case upsert:
+			// we've already handled upserts in [preProcessUpserts]
 			continue
 		case noOp:
 			continue
 		}
+		updateStats(&stats, m)
 	}
 	v.root.Store(root)
-	return nil
+	return stats, nil
+}
+
+func updateStats(s *MutationStats, m Mutation) {
+	switch m.countAs {
+	case add:
+		s.Added++
+	case move:
+		s.Moved++
+	case update:
+		s.Updated++
+	case deleteOp:
+		s.Deleted++
+	}
+	if m.shardChange {
+		s.ChangedShards++
+	}
 }
 
 // shallowCopy makes a shallow copy of r, so that we can modify its Rules map.

--- a/vault_hellish_test.go
+++ b/vault_hellish_test.go
@@ -152,7 +152,7 @@ func TestHellishShardedVaultParallelStress(t *testing.T) {
 				newRule := indigo.NewRule(ruleID, fmt.Sprintf("tier > %d", rng.Intn(10)))
 				parentID := selectRandomParent(v.ImmutableRule(), rng)
 				if parentID != "" {
-					err := v.Mutate(indigo.Add(newRule, parentID))
+					_, err := v.Mutate(indigo.Add(newRule, parentID))
 					if err != nil {
 						t.Logf("Add mutation error for %s: %v", ruleID, err)
 						atomic.AddInt64(&mutationErrors, 1)
@@ -166,7 +166,7 @@ func TestHellishShardedVaultParallelStress(t *testing.T) {
 					targetID := allRules[rng.Intn(len(allRules))]
 					updatedExpr := fmt.Sprintf("priority > %d", rng.Intn(100))
 					updatedRule := indigo.NewRule(targetID, updatedExpr)
-					err := v.Mutate(indigo.Update(updatedRule))
+					_, err := v.Mutate(indigo.Update(updatedRule))
 					if err != nil {
 						t.Logf("Update mutation error for %s: %v", targetID, err)
 						atomic.AddInt64(&mutationErrors, 1)
@@ -178,7 +178,7 @@ func TestHellishShardedVaultParallelStress(t *testing.T) {
 				allRules := collectAllRuleIDs(rule)
 				if len(allRules) > 2 { // Don't delete root
 					targetID := allRules[1+rng.Intn(len(allRules)-1)]
-					err := v.Mutate(indigo.Delete(targetID))
+					_, err := v.Mutate(indigo.Delete(targetID))
 					if err != nil {
 						t.Logf("Delete mutation error for %s: %v", targetID, err)
 						atomic.AddInt64(&mutationErrors, 1)
@@ -192,7 +192,7 @@ func TestHellishShardedVaultParallelStress(t *testing.T) {
 					sourceID := allRules[1+rng.Intn(len(allRules)-1)]
 					targetParentID := selectRandomParent(v.ImmutableRule(), rng)
 					if targetParentID != "" && targetParentID != sourceID {
-						err := v.Mutate(indigo.Move(sourceID, targetParentID))
+						_, err := v.Mutate(indigo.Move(sourceID, targetParentID))
 						if err != nil {
 							t.Logf("Move mutation error from %s: %v", sourceID, err)
 							atomic.AddInt64(&mutationErrors, 1)
@@ -257,7 +257,7 @@ func TestHellishShardedVaultParallelStress(t *testing.T) {
 			updateExpr := fmt.Sprintf(`category == "%s" && region == "%s"`, category, region)
 			updateRule := indigo.NewRule(fmt.Sprintf("category_shard_%s", category), updateExpr)
 
-			err := v.Mutate(indigo.Update(updateRule))
+			_, err := v.Mutate(indigo.Update(updateRule))
 			if err != nil {
 				t.Logf("Shard update error: %v", err)
 				atomic.AddInt64(&mutationErrors, 1)
@@ -368,7 +368,7 @@ func TestExtremeShardingEdgeCases(t *testing.T) {
 
 		// Add a rule that matches shard_a
 		ruleA := indigo.NewRule("rule_a", `type == "A"`)
-		if err := v.Mutate(indigo.Add(ruleA, "root")); err != nil {
+		if _, err := v.Mutate(indigo.Add(ruleA, "root")); err != nil {
 			t.Fatalf("add rule_a failed: %v", err)
 		}
 
@@ -382,7 +382,7 @@ func TestExtremeShardingEdgeCases(t *testing.T) {
 			t.Error("rule_a not in shard_a")
 		}
 		updated := indigo.NewRule("rule_a", `type == "C"`)
-		if err := v.Mutate(indigo.Update(updated)); err != nil {
+		if _, err := v.Mutate(indigo.Update(updated)); err != nil {
 			t.Fatalf("update rule_a failed: %v", err)
 		}
 
@@ -434,7 +434,7 @@ func TestExtremeShardingEdgeCases(t *testing.T) {
 		debugLogf(t, "before:\n%s\n", v.ImmutableRule())
 		// Add rules at various levels
 		rule1 := indigo.NewRule("rule1", `type == "primary_sec1"`)
-		if err := v.Mutate(indigo.Add(rule1, "root")); err != nil {
+		if _, err := v.Mutate(indigo.Add(rule1, "root")); err != nil {
 			t.Fatalf("add rule1 failed: %v", err)
 		}
 
@@ -451,7 +451,7 @@ func TestExtremeShardingEdgeCases(t *testing.T) {
 
 		// Update it to match sec2
 		updated := indigo.NewRule("rule1", `type == "primary_sec2"`)
-		if err := v.Mutate(indigo.Update(updated)); err != nil {
+		if _, err := v.Mutate(indigo.Update(updated)); err != nil {
 			t.Fatalf("update rule1 failed: %v", err)
 		}
 
@@ -546,7 +546,7 @@ func TestConcurrentUpdateWithParallelEval(t *testing.T) {
 					newExpr := fmt.Sprintf("x > %d", rng.Intn(100))
 					updateRule := indigo.NewRule(targetID, newExpr)
 
-					err := v.Mutate(indigo.Update(updateRule))
+					_, err := v.Mutate(indigo.Update(updateRule))
 					if err == nil {
 						atomic.AddInt64(&mutCount, 1)
 					}

--- a/vault_test.go
+++ b/vault_test.go
@@ -39,11 +39,11 @@ func TestVault_NestedAdd(t *testing.T) {
 	e.Compile(r)
 	debugLogf(t, "Before add\n%s\n", v.ImmutableRule().Tree())
 	t1 := time.Date(2020, 10, 10, 12, 0o0, 0o0, 0o0, time.UTC)
-	if err := v.Mutate(indigo.LastUpdate(t1)); err != nil {
+	if _, err := v.Mutate(indigo.LastUpdate(t1)); err != nil {
 		t.Fatal(err)
 	}
 	t2 := time.Date(2022, 10, 10, 12, 0o0, 0o0, 0o0, time.UTC)
-	if err := v.Mutate(indigo.Add(r, "c33"), indigo.LastUpdate(t2)); err != nil {
+	if _, err := v.Mutate(indigo.Add(r, "c33"), indigo.LastUpdate(t2)); err != nil {
 		t.Fatal(err)
 	}
 	debugLogf(t, "After add\n%s\n", v.ImmutableRule().Tree())
@@ -139,18 +139,18 @@ func TestVault_Concurrency(t *testing.T) {
 				}
 
 			}
-			if err := v.Mutate(indigo.Update(r)); err != nil {
+			if _, err := v.Mutate(indigo.Update(r)); err != nil {
 				t.Fatal(err)
 			}
 
 			// Move c1 back and forth between a and c
 			cr := v.ImmutableRule()
 			if _, ok := cr.Rules["c"].Rules["c1"]; ok {
-				if err := v.Mutate(indigo.Move("c1", "a")); err != nil {
+				if _, err := v.Mutate(indigo.Move("c1", "a")); err != nil {
 					t.Fatal(err)
 				}
 			} else {
-				if err := v.Mutate(indigo.Move("c1", "c")); err != nil {
+				if _, err := v.Mutate(indigo.Move("c1", "c")); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -204,14 +204,14 @@ func TestVault_AddInvalidInputs(t *testing.T) {
 
 	// Add with empty ID
 	r := indigo.Rule{ID: "", Expr: "true"}
-	err := v.Mutate(indigo.Add(&r, "root"))
+	_, err := v.Mutate(indigo.Add(&r, "root"))
 	if err == nil {
 		t.Error("expected error for empty ID")
 	}
 
 	// Add to non-existent parent
 	r2 := indigo.Rule{ID: "test", Expr: "true"}
-	err = v.Mutate(indigo.Add(&r2, "nonexistent"))
+	_, err = v.Mutate(indigo.Add(&r2, "nonexistent"))
 	if err == nil {
 		t.Error("expected error for non-existent parent")
 	}
@@ -222,7 +222,7 @@ func TestVault_UpdateInvalid(t *testing.T) {
 
 	// Update non-existent
 	r := indigo.Rule{ID: "nonexistent", Expr: "true"}
-	err := v.Mutate(indigo.Update(&r))
+	_, err := v.Mutate(indigo.Update(&r))
 	if err == nil {
 		t.Error("expected error for updating non-existent rule")
 	}
@@ -235,31 +235,31 @@ func TestVault_MoveInvalid(t *testing.T) {
 	a := indigo.Rule{ID: "a", Expr: "true", Rules: map[string]*indigo.Rule{
 		"child": {ID: "child", Expr: "true"},
 	}}
-	err := v.Mutate(indigo.Add(&a, "root"))
+	_, err := v.Mutate(indigo.Add(&a, "root"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Move to non-existent parent
-	err = v.Mutate(indigo.Move("a", "nonexistent"))
+	_, err = v.Mutate(indigo.Move("a", "nonexistent"))
 	if err == nil {
 		t.Error("expected error for moving to non-existent parent")
 	}
 
 	// Move non-existent rule
-	err = v.Mutate(indigo.Move("nonexistent", "root"))
+	_, err = v.Mutate(indigo.Move("nonexistent", "root"))
 	if err == nil {
 		t.Error("expected error for moving non-existent rule")
 	}
 
 	// Move to self
-	err = v.Mutate(indigo.Move("a", "a"))
+	_, err = v.Mutate(indigo.Move("a", "a"))
 	if err == nil {
 		t.Error("expected error for moving to self")
 	}
 
 	// Move to descendant
-	err = v.Mutate(indigo.Move("a", "child"))
+	_, err = v.Mutate(indigo.Move("a", "child"))
 	if err == nil {
 		t.Error("expected error for moving to descendant")
 	}
@@ -269,7 +269,7 @@ func TestVault_DeleteInvalid(t *testing.T) {
 	v := setup(t)
 
 	// Delete root
-	err := v.Mutate(indigo.Delete("root"))
+	_, err := v.Mutate(indigo.Delete("root"))
 	if err == nil {
 		t.Error("expected error for deleting root")
 	}
@@ -282,7 +282,7 @@ func TestVault_MultipleMutationsWithError(t *testing.T) {
 	r2 := indigo.Rule{ID: "r2", Expr: "true"}
 	invalid := indigo.Rule{ID: "", Expr: "true"} // empty ID
 
-	err := v.Mutate(indigo.Add(&r1, "root"), indigo.Add(&invalid, "root"), indigo.Add(&r2, "root"))
+	_, err := v.Mutate(indigo.Add(&r1, "root"), indigo.Add(&invalid, "root"), indigo.Add(&r2, "root"))
 	if err == nil {
 		t.Error("expected error in multiple mutations")
 	}
@@ -345,7 +345,7 @@ func TestVault_ConcurrentMutations_RaceCondition(t *testing.T) {
 			ruleID := fmt.Sprintf("rule_%d", id)
 			newRule := indigo.NewRule(ruleID, "true")
 
-			if err := v.Mutate(indigo.Add(newRule, "root")); err != nil {
+			if _, err := v.Mutate(indigo.Add(newRule, "root")); err != nil {
 				t.Errorf("Mutate failed for %s: %v", ruleID, err)
 			}
 		}(i)
@@ -418,12 +418,12 @@ func TestVault_Mutations(t *testing.T) {
 		baseline := v.ImmutableRule()
 		debugLogf(t, "baseline:\n%s\n", baseline)
 
-		err := v.Mutate(indigo.Delete("z"))
+		_, err := v.Mutate(indigo.Delete("z"))
 		if err != nil {
 			t.Fatalf("Updating rule failed: %v", err)
 		}
 		// delete rule that doesn't exist
-		err = v.Mutate(indigo.Delete("bogus"))
+		_, err = v.Mutate(indigo.Delete("bogus"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -463,7 +463,7 @@ func TestVault_Mutations(t *testing.T) {
 		baseline := v.ImmutableRule()
 		debugLogf(t, "baseline:\n%s\n", baseline)
 
-		err := v.Mutate(indigo.Update(indigo.NewRule("one", "true")))
+		_, err := v.Mutate(indigo.Update(indigo.NewRule("one", "true")))
 		if err != nil {
 			t.Fatalf("Updating rule failed: %v", err)
 		}
@@ -515,7 +515,7 @@ func TestVault_Mutations(t *testing.T) {
 		savedPtrs["y"] = baseline.Rules["childD"].Rules["y"]
 		savedPtrs["z"] = baseline.Rules["childD"].Rules["z"]
 
-		err := v.Mutate(indigo.Add(indigo.NewRule("zzz", "false"), "z"))
+		_, err := v.Mutate(indigo.Add(indigo.NewRule("zzz", "false"), "z"))
 		if err != nil {
 			t.Fatalf("adding rule failed: %v", err)
 		}
@@ -653,7 +653,7 @@ func TestVault_Mutations(t *testing.T) {
 		baseline := v.ImmutableRule()
 		debugLogf(t, "baseline:\n%s\n", baseline)
 
-		err := v.Mutate(indigo.Move("two", "childC"))
+		_, err := v.Mutate(indigo.Move("two", "childC"))
 		if err != nil {
 			t.Fatalf("moving rule failed: %v", err)
 		}
@@ -696,7 +696,7 @@ func TestVault_Mutations(t *testing.T) {
 		baseline := v.ImmutableRule()
 		debugLogf(t, "baseline:\n%s\n", baseline)
 
-		err := v.Mutate(indigo.Update(indigo.NewRule("root", "true")))
+		_, err := v.Mutate(indigo.Update(indigo.NewRule("root", "true")))
 		if err != nil {
 			t.Fatalf("adding rule failed: %v", err)
 		}
@@ -730,7 +730,7 @@ func TestVault_Mutations(t *testing.T) {
 		mut = append(mut, indigo.Update(indigo.NewRule("root", "true")))
 		mut = append(mut, indigo.Add(indigo.NewRule("a", "2+2=4"), "root"))
 		mut = append(mut, indigo.Add(indigo.NewRule("b", "false"), "a"))
-		err := v.Mutate(mut...)
+		_, err := v.Mutate(mut...)
 		if err != nil {
 			t.Fatalf("adding rule failed: %v", err)
 		}
@@ -765,7 +765,7 @@ func TestVault_Mutations(t *testing.T) {
 		mut = append(mut, indigo.Add(indigo.NewRule("a", "2+2=4"), "root"))
 		mut = append(mut, indigo.Update(indigo.NewRule("root", "true")))
 		mut = append(mut, indigo.Add(indigo.NewRule("b", "false"), "a"))
-		err := v.Mutate(mut...)
+		_, err := v.Mutate(mut...)
 		if err == nil {
 			t.Fatalf("wanted error")
 		}
@@ -784,7 +784,7 @@ func TestVault_Mutations(t *testing.T) {
 		mut = append(mut, indigo.Add(indigo.NewRule("a", "2+2=4"), "root"))
 		mut = append(mut, indigo.Update(indigo.NewRule("root", "true")))
 		mut = append(mut, indigo.Add(indigo.NewRule("b", "false"), "a"))
-		err := v.Mutate(mut...)
+		_, err := v.Mutate(mut...)
 		if err == nil {
 			t.Fatalf("wanted error")
 		}
@@ -801,7 +801,7 @@ func TestVault_Mutations(t *testing.T) {
 
 		// childA already exists in the baseline, as a child of root
 		mut = append(mut, indigo.Add(indigo.NewRule("childA", "2+2=4"), "childD"))
-		err := v.Mutate(mut...)
+		_, err := v.Mutate(mut...)
 		if err == nil {
 			t.Fatalf("wanted error")
 		}
@@ -812,7 +812,7 @@ func TestVault_Mutations(t *testing.T) {
 		// verify that an upsert works
 		mut = []indigo.Mutation{}
 		mut = append(mut, indigo.Upsert(indigo.NewRule("childA", "2+2=4")))
-		err = v.Mutate(mut...)
+		_, err = v.Mutate(mut...)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -919,7 +919,7 @@ func TestVaultParallelEvalWithShardedMutations(t *testing.T) {
 
 				// Add rules to root - this will clone root and modify its Rules map
 				newRule := indigo.NewRule(fmt.Sprintf("added_%d_%d", id, counter), "x > 5")
-				err := v.Mutate(indigo.Add(newRule, "root"))
+				_, err := v.Mutate(indigo.Add(newRule, "root"))
 				if err != nil && ctx.Err() == nil {
 					errChan <- fmt.Errorf("add error from worker %d: %w", id, err)
 				}
@@ -945,7 +945,7 @@ func TestVaultParallelEvalWithShardedMutations(t *testing.T) {
 				// Update rules that exist
 				targetID := fmt.Sprintf("initial_%d", counter%20)
 				updated := indigo.NewRule(targetID, fmt.Sprintf("x > %d", counter%100))
-				err := v.Mutate(indigo.Update(updated))
+				_, err := v.Mutate(indigo.Update(updated))
 				if err != nil && ctx.Err() == nil {
 					errChan <- fmt.Errorf("update error from worker %d: %w", id, err)
 				}
@@ -1033,7 +1033,7 @@ func TestRaceConditionRulesMapMutation(t *testing.T) {
 			targetID := fmt.Sprintf("child_%d", counter%50)
 			newRule := indigo.NewRule(targetID, fmt.Sprintf("x > %d", counter%100))
 
-			_ = v.Mutate(indigo.Update(newRule))
+			v.Mutate(indigo.Update(newRule))
 			counter++
 		}
 	}()
@@ -1077,9 +1077,9 @@ func TestRaceConditionRulesMapMutation(t *testing.T) {
 
 			if counter%2 == 0 {
 				parentID := fmt.Sprintf("child_%d", counter%50)
-				_ = v.Mutate(indigo.Add(newRule, parentID))
+				v.Mutate(indigo.Add(newRule, parentID))
 			} else {
-				_ = v.Mutate(indigo.Add(newRule, parent))
+				v.Mutate(indigo.Add(newRule, parent))
 			}
 			counter++
 		}
@@ -1164,7 +1164,7 @@ func TestParallelEvalDuringMutation(t *testing.T) {
 				childID := fmt.Sprintf("parent_%d_child_%d_added_%d", i%5, i%20, i)
 				newRule := indigo.NewRule(childID, fmt.Sprintf("x > %d", i))
 
-				_ = v.Mutate(indigo.Add(newRule, parentID))
+				v.Mutate(indigo.Add(newRule, parentID))
 			}
 		}(mutator)
 	}
@@ -1245,7 +1245,7 @@ func TestSortedRulesRaceCondition(t *testing.T) {
 			}
 
 			newRule := indigo.NewRule(fmt.Sprintf("added_%d", counter), "x > 0")
-			_ = v.Mutate(indigo.Add(newRule, "root"))
+			v.Mutate(indigo.Add(newRule, "root"))
 			counter++
 		}
 	}()
@@ -1264,7 +1264,7 @@ func TestSortedRulesRaceCondition(t *testing.T) {
 
 			targetID := fmt.Sprintf("child_%d", counter%100)
 			updated := indigo.NewRule(targetID, fmt.Sprintf("x > %d", counter%50))
-			_ = v.Mutate(indigo.Update(updated))
+			v.Mutate(indigo.Update(updated))
 			counter++
 		}
 	}()
@@ -1331,7 +1331,7 @@ func TestDestinationShardRaceCondition(t *testing.T) {
 			}
 
 			newRule := indigo.NewRule(fmt.Sprintf("rule_%d", counter), "true")
-			_ = v.Mutate(indigo.Add(newRule, "root"))
+			v.Mutate(indigo.Add(newRule, "root"))
 			counter++
 		}
 	}()
@@ -1350,7 +1350,7 @@ func TestDestinationShardRaceCondition(t *testing.T) {
 
 			targetID := fmt.Sprintf("rule_%d", counter%100)
 			updated := indigo.NewRule(targetID, "true")
-			_ = v.Mutate(indigo.Update(updated))
+			v.Mutate(indigo.Update(updated))
 			counter++
 		}
 	}()
@@ -1433,7 +1433,7 @@ func TestVaultMutateRulesMapDirectModification(t *testing.T) {
 
 			// Add children to parent - triggers Rules map modification in makeSafe
 			newRule := indigo.NewRule(fmt.Sprintf("newchild_%d", counter), "x > 10")
-			_ = v.Mutate(indigo.Add(newRule, "parent"))
+			v.Mutate(indigo.Add(newRule, "parent"))
 			counter++
 		}
 	})
@@ -1519,7 +1519,7 @@ func TestVaultMutationDeadlock(t *testing.T) {
 
 			// Add children to parent
 			newRule := indigo.NewRule(fmt.Sprintf("newchild_%d", counter), "x > 10")
-			_ = v.Mutate(indigo.Add(newRule, "parent"))
+			v.Mutate(indigo.Add(newRule, "parent"))
 			mutateCount.Add(1)
 			counter++
 		}
@@ -1604,7 +1604,7 @@ func TestVaultParallelEvalMutationDeadlock(t *testing.T) {
 			}
 
 			newRule := indigo.NewRule(fmt.Sprintf("newchild_%d", counter), "x > 10")
-			_ = v.Mutate(indigo.Add(newRule, "parent"))
+			v.Mutate(indigo.Add(newRule, "parent"))
 			mutateCount.Add(1)
 			counter++
 		}

--- a/vaultbench_test.go
+++ b/vaultbench_test.go
@@ -72,7 +72,7 @@ func BenchmarkVault_Mutate_LargeTree_10k(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		// This is the hot path we're measuring
-		err := vault.Mutate(indigo.Update(&updateRule))
+		_, err := vault.Mutate(indigo.Update(&updateRule))
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -91,7 +91,7 @@ func BenchmarkVault_Mutate_LargeTree_10k_Move(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		// Move a leaf node from one parent to another
-		err := vault.Mutate(indigo.Move("Z99", "A11")) // assume these exist
+		_, err := vault.Mutate(indigo.Move("Z99", "A11")) // assume these exist
 		if err != nil {
 			continue
 			// b.Fatal(err)


### PR DESCRIPTION
This PR adds statistics to Vault mutations and Engine rule evaluations:

* The Vault’s Mutate method now returns a count of operation by mutation type (update, add, etc.) performed by the Vault. Due to sharding and upserting the counts may not match the list of mutations submitted by the client. 
* The Engine’s Eval method now returns a count of rules whose expressions were evaluated in the Result struct.